### PR TITLE
added unit tests for regex function with valid, invalid and empty cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 .env
 
 # ===== python 3.7 venv =====
-syncnet_python/venv/
+venv/
 
 # ===== log files =====
 syncnet_python/logs

--- a/syncnet_python/tests/test_utils/test_analysis_utils.py
+++ b/syncnet_python/tests/test_utils/test_analysis_utils.py
@@ -123,6 +123,80 @@ class TestAnalysisUtils(unittest.TestCase):
         finally:
             os.remove(tmp_log_path)
 
+
+            # ------------------ extract_offset_confidence_pairs unit tests ------------------ #
+
+    # testing extract_offset_confidence_pairs with valid log content
+    def test_extract_offset_confidence_pairs_valid_log_content(self):
+        """
+        Testing the extract_offset_confidence_pairs function with valid log contents.
+        Expecting the function to return the right list of offset and confidence pairs.
+        """
+        valid_log = """\
+        AV offset:   15
+        Confidence:  0.116
+        AV offset:   14
+        Confidence:  0.661
+        AV offset:   -7
+        Confidence:  3.162
+        AV offset:   15
+        Confidence:  0.412
+        AV offset:   -6
+        Confidence:  8.271
+        AV offset:   -7
+        Confidence:  8.789
+        AV offset:   11
+        Confidence:  0.466
+        AV offset:   -7
+        Confidence:  7.931
+        """
+
+        expected_pairs = [
+            (15, 0.116),
+            (14, 0.661),
+            (-7, 3.162),
+            (15, 0.412),
+            (-6, 8.271),
+            (-7, 8.789),
+            (11, 0.466),
+            (-7, 7.931)
+        ]
+
+        result = AnalysisUtils.extract_offset_confidence_pairs(valid_log)
+        self.assertEqual(result, expected_pairs, "The function should properly extract all valid offset and confidence pairs.")
+
+    # testing extract_offset_confidence_pairs with valid log content
+    def test_extract_offset_confidence_pairs_invalid_log_content(self):
+        """
+        Testing the extract_offset_confidence_pairs function with invalid log contents.
+        Expecting the function to return an empty list because no valid pairs are there.
+        """
+        invalid_log= """\
+        AV offset:   tryh5e6d/hg
+        Confidence:  rdhrtht.546
+        ghdtrdhfrdthfdhndhrtdjtr
+        gt878dg7fdgd78ddf87hfd8h
+        """
+
+        expected_pairs = []
+
+        result = AnalysisUtils.extract_offset_confidence_pairs(invalid_log)
+        self.assertEqual(result, expected_pairs, "The function should return an empty list when no valid pairs are found.")
+
+    # testing extract_offset_confidence_pairs with valid log content
+    def test_extract_offset_confidence_pairs_empty_log_content(self):
+        """
+        Testing the extract_offset_confidence_pairs function with empty log content.
+        Expecting the function to return an empty list.
+        """
+        empty_log = ""
+
+        expected_pairs = []
+
+        result = AnalysisUtils.extract_offset_confidence_pairs(empty_log)
+        self.assertEqual(result, expected_pairs, "The function should return an empty list for empty log content.")
+
+
             
 
     


### PR DESCRIPTION
Added three unit tests for the regex function 'extract_offset_confidence_pairs' with valid, invalid and empty log content